### PR TITLE
Fix build task problem in GNU/Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,35 +1,9 @@
-# Prerequisites
-*.d
-
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
-
 .vscode/*
+*
+!.gitignore
+!src
+!examples
+!*.md
+!COPYING
+!COPYING.LESSER
 !.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "args": [
                 "-std=c++11",
                 "-o",
-                "test01.exe",
+                "test01",
                 "examples\\01.cpp",
                 "src\\ctimmy.cpp"
             ],
@@ -39,7 +39,7 @@
                 "-Wpedantic",
                 "-O3",
                 "-o",
-                "test01.exe",
+                "test01",
                 "examples\\01.cpp",
                 "src\\ctimmy.cpp"
             ],


### PR DESCRIPTION
- Change output name in _tasks.json_ from _test01.exe_ to _test01_